### PR TITLE
docs: Simplificar README principal eliminando secciones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Proyecto de Clase - Modelos de Machine Learning
+
+Este repositorio contiene una colección de scripts de Python desarrollados para diferentes materias, enfocados en la implementación y explicación de modelos de machine learning.
+
+## Estructura del Repositorio
+
+El proyecto está organizado en las siguientes carpetas:
+
+- **`econometria-2/`**: Contiene scripts relacionados con la materia de Econometría II.
+- **`prob-y-est/`**: Contiene scripts relacionados con la materia de Probabilidad y Estadística.
+
+Cada carpeta tiene su propio `README.md` que detalla el contenido específico de los scripts que aloja.
+
+## Requisitos
+
+Para ejecutar los scripts de este proyecto, necesitarás Python 3 y las librerías listadas en el archivo `requirements.txt`.

--- a/econometria-2/README.md
+++ b/econometria-2/README.md
@@ -1,0 +1,20 @@
+# Econometría II
+
+Esta carpeta contiene scripts y proyectos relacionados con la materia de Econometría II.
+
+## Contenido
+
+### `red-neuronal-mtcars.py`
+
+Este script implementa un **Perceptrón Multicapa (MLP)**, un tipo de red neuronal, para resolver un problema de clasificación.
+
+- **Objetivo**: Clasificar el número de cilindros (`cyl`) de los automóviles del famoso dataset `mtcars`.
+- **Librerías**: Utiliza `scikit-learn` para el modelo, `pandas` para la manipulación de datos y `matplotlib`/`seaborn` para las visualizaciones.
+
+El código está extensamente comentado para servir como una guía de aprendizaje sobre los siguientes temas:
+- La importancia de escalar los datos de entrada.
+- Cómo dividir los datos en conjuntos de entrenamiento y prueba sin "fuga de información" (`data leakage`).
+- El uso de `Pipeline` en `scikit-learn` para encapsular el preprocesamiento y el modelo.
+- Los conceptos básicos de un MLP: capas, neuronas y funciones de activación.
+- El significado de los hiperparámetros clave del modelo.
+- Cómo evaluar el rendimiento del clasificador a través de métricas como *accuracy*, la matriz de confusión y la curva de pérdida.

--- a/prob-y-est/README.md
+++ b/prob-y-est/README.md
@@ -1,0 +1,24 @@
+# Probabilidad y Estadística
+
+Esta carpeta contiene scripts y proyectos relacionados con la materia de Probabilidad y Estadística.
+
+## Contenido
+
+### `red-neuronal-breast-cancer.py`
+
+Este script es una guía práctica que compara dos enfoques de clasificación para el dataset de cáncer de mama de Wisconsin:
+
+1.  **K-Nearest Neighbors (KNN)**: Un modelo basado en instancias.
+2.  **Perceptrón Multicapa (MLP)**: Una red neuronal.
+
+- **Objetivo**: Clasificar si un tumor es benigno o maligno.
+- **Librerías**: Utiliza `scikit-learn`, `pandas`, `numpy`, `matplotlib` y `seaborn`.
+
+El código está diseñado como un tutorial y explica en detalle los siguientes conceptos:
+- La correcta división de datos en entrenamiento, validación y prueba.
+- El escalado de variables y cómo evitar la fuga de información (`data leakage`).
+- La selección del hiperparámetro `k` en KNN mediante validación cruzada.
+- El entrenamiento de un MLP "por épocas" simuladas.
+- La implementación de *early stopping* manual para prevenir el sobreajuste.
+- La evaluación de clasificadores con métricas como F1-score, ROC-AUC y PR-AUC.
+- La visualización de la arquitectura de la red neuronal entrenada.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+scikit-learn
+pandas
+numpy
+matplotlib
+seaborn


### PR DESCRIPTION
Se eliminan las secciones 'Instalación' y 'Uso' del `README.md` principal para simplificar el contenido, según la solicitud del usuario. El archivo ahora se enfoca en la descripción del proyecto y los requisitos.